### PR TITLE
fix the table of mainsite listing

### DIFF
--- a/src/app/(admin)/listing/components/LenderListingContainer.tsx
+++ b/src/app/(admin)/listing/components/LenderListingContainer.tsx
@@ -39,7 +39,7 @@ export default function LenderListingContainer({
   // TanStack pagination state
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 3,
+    pageSize: 10,
   })
 
   // Reset page when filters change

--- a/src/app/(admin)/listing/components/MainLisitngContainer.tsx
+++ b/src/app/(admin)/listing/components/MainLisitngContainer.tsx
@@ -38,7 +38,7 @@ export default function MainListingContainer({
   // TanStack pagination state
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 3,
+    pageSize: 10,
   })
 
   // Reset to first page when search changes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased default items per page from 3 to 10 across Admin listings (Main and Lender), showing more results per page for smoother browsing and fewer page flips.
  - Pagination and total page counts adjust automatically with the new size; lists load larger batches per view.
  - Search, filters, and loading/error handling remain unchanged; no UI layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->